### PR TITLE
Implement shareable link mode

### DIFF
--- a/src/Components/SharedConsole.tsx
+++ b/src/Components/SharedConsole.tsx
@@ -3,27 +3,19 @@ import { Autocomplete as MapsAutocomplete } from "@react-google-maps/api";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from "@mui/material/Switch";
 import React from "react";
 import { useState } from "react";
 
 type ConsoleProps = any;
 
-const Console = (props: ConsoleProps) => {
+const SharedConsole = (props: ConsoleProps) => {
   const {
-    yourPlace,
-    handleYourPlaceChanged,
+    name,
     theirPlace,
-    handleTheirPlaceChanged,
-    linkSharingMode,
-    setLinkSharingMode
+    handleTheirPlaceChanged
   } = props;
 
-  const [yourRawLocation, setYourRawLocation] = useState<string>("");
   const [theirRawLocation, setTheirRawLocation] = useState<string>("");
-  const [yourAutocomplete, setYourAutocomplete] = useState<any>(undefined);
   const [theirAutocomplete, setTheirAutocomplete] = useState<any>(undefined);
 
   return (
@@ -35,29 +27,9 @@ const Console = (props: ConsoleProps) => {
         }
       />
       <CardContent>
-        <FormGroup style={{margin: '10px'}}>
-          <FormControlLabel control={<Switch checked={linkSharingMode} onChange={() => setLinkSharingMode(!linkSharingMode)}/>} label="Link Sharing" />
-        </FormGroup>
-        <MapsAutocomplete
-          onPlaceChanged={() => {
-            const place: google.maps.places.PlaceResult =
-              yourAutocomplete.getPlace();
-            handleYourPlaceChanged(place);
-          }}
-          onLoad={(autocomplete) => {
-            setYourAutocomplete(autocomplete);
-          }}
-        >
-          <TextField
-            onChange={(e) => {
-              handleYourPlaceChanged(undefined);
-              setYourRawLocation(e.target.value);
-            }}
-            label="Your place"
-            value={yourPlace?.formatted_address ?? yourRawLocation}
-            fullWidth
-          />
-        </MapsAutocomplete>
+        <Typography>
+            {name}'s location is mapped. Enter yours to search in between.
+        </Typography>
         <div style={{margin: '25px'}} />
         <MapsAutocomplete
           onPlaceChanged={() => {
@@ -70,7 +42,7 @@ const Console = (props: ConsoleProps) => {
           }}
         >
           <TextField
-            label="Their place"
+            label="Your place"
             onChange={(e) => {
               handleTheirPlaceChanged(undefined);
               setTheirRawLocation(e.target.value);
@@ -84,4 +56,4 @@ const Console = (props: ConsoleProps) => {
   );
 };
 
-export { Console };
+export { SharedConsole };

--- a/src/Components/StartConsole.tsx
+++ b/src/Components/StartConsole.tsx
@@ -1,5 +1,7 @@
 import { TextField, Typography } from "@mui/material";
 import { Autocomplete as MapsAutocomplete } from "@react-google-maps/api";
+import Alert from "@mui/material/Alert";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
@@ -11,20 +13,39 @@ import { useState } from "react";
 
 type ConsoleProps = any;
 
-const Console = (props: ConsoleProps) => {
+const StartConsole = (props: ConsoleProps) => {
   const {
     yourPlace,
     handleYourPlaceChanged,
-    theirPlace,
-    handleTheirPlaceChanged,
     linkSharingMode,
     setLinkSharingMode
   } = props;
 
+  const [yourName, setYourName] = useState<string>("");
   const [yourRawLocation, setYourRawLocation] = useState<string>("");
-  const [theirRawLocation, setTheirRawLocation] = useState<string>("");
   const [yourAutocomplete, setYourAutocomplete] = useState<any>(undefined);
-  const [theirAutocomplete, setTheirAutocomplete] = useState<any>(undefined);
+  const [alertSuccess, setAlertSuccess] = useState<boolean>(false);
+  const [alertMsg, setAlertMsg] = useState<string>("");
+
+  const getShareableLink = () => {
+    if (!yourName) {
+        createAlert(false, "Please enter your name");
+    } else if (!yourPlace) {
+        createAlert(false, "Please enter a valid location");
+    } else {
+        createAlert(true, "Link copied to clipboard");
+        navigator.clipboard.writeText(`${window.location.origin}?name=${yourName}&sharedPlaceId=${yourPlace.place_id}`);
+    }
+  };
+
+  const createAlert = (type: boolean, msg: string) => {
+        setAlertSuccess(type);
+        setAlertMsg(msg);
+        setTimeout(() => {
+            setAlertSuccess(false);
+            setAlertMsg("");
+        }, 2000);
+  };
 
   return (
     <Card style={{width: '350px'}}>
@@ -36,8 +57,18 @@ const Console = (props: ConsoleProps) => {
       />
       <CardContent>
         <FormGroup style={{margin: '10px'}}>
-          <FormControlLabel control={<Switch checked={linkSharingMode} onChange={() => setLinkSharingMode(!linkSharingMode)}/>} label="Link Sharing" />
+            <FormControlLabel control={<Switch checked={linkSharingMode} onChange={() => setLinkSharingMode(!linkSharingMode)}/>} label="Link Sharing" />
         </FormGroup>
+        <TextField
+            label="Your name"
+            onChange={(e) => {
+              setYourName(e.target.value);
+            }}
+            value={yourName}
+            placeholder="Enter your name"
+            fullWidth
+        />
+        <div style={{margin: '25px'}} />
         <MapsAutocomplete
           onPlaceChanged={() => {
             const place: google.maps.places.PlaceResult =
@@ -58,30 +89,15 @@ const Console = (props: ConsoleProps) => {
             fullWidth
           />
         </MapsAutocomplete>
-        <div style={{margin: '25px'}} />
-        <MapsAutocomplete
-          onPlaceChanged={() => {
-            const place: google.maps.places.PlaceResult =
-              theirAutocomplete.getPlace();
-            handleTheirPlaceChanged(place);
-          }}
-          onLoad={(autocomplete) => {
-            setTheirAutocomplete(autocomplete);
-          }}
-        >
-          <TextField
-            label="Their place"
-            onChange={(e) => {
-              handleTheirPlaceChanged(undefined);
-              setTheirRawLocation(e.target.value);
-            }}
-            value={theirPlace?.formatted_address ?? theirRawLocation}
-            fullWidth
-          />
-        </MapsAutocomplete>
+        <div style={{margin: '15px'}} />
+        <Button fullWidth onClick={getShareableLink} variant="contained">Get shareable link</Button>
+        { alertMsg 
+            ? <Alert severity={alertSuccess ? "success" : "error"} style={{marginTop: '10px'}}>{alertMsg}</Alert>
+            : <div/>
+        }
       </CardContent>
     </Card>
   );
 };
 
-export { Console };
+export { StartConsole };


### PR DESCRIPTION
This PR implements a shareable link mode. The existing console requires a single user to input both their location and the location of another person. This PR adds a toggle switch that allows the user to switch into shareable link mode. Once toggled on, the user will see a console that requests their name and location. After this data is entered, the user can click on a button to copy a shareable link to their clipboard. The link contains query parameters that contain the name of the sender and the place_id of their location. If another user visits this link, they will see the sender's location on the map, as well as an input for their own location. Entering this data will result in recommended places being shown between them.
﻿
